### PR TITLE
Suggestions by Gataca

### DIFF
--- a/interface-specs/data-agreement-schema/v1/data-agreement-schema.json
+++ b/interface-specs/data-agreement-schema/v1/data-agreement-schema.json
@@ -1,57 +1,73 @@
 {
   "@context": "https://schema.igrant.io/data-agreements/v1",
-  "data_agreement_id": "d7216cb1-aedb-471e-96f7-7fef51dedb76",
-  "data_agreement_version": "v1.0",
-  "data_agreement_template_id": "91be609a-4acd-468f-b37a-0f379893b65c",
-  "data_agreement_template_version": "v1.0",
-  "usage_purpose": "Customized shopping experience",
-  "usage_purpose_description": "Collecting user data for offering custom tailored shopping experience",
-  "legal_basis": "<consent/legal_obligation/contract/vital_interest/public_task/legitimate_interest>",
+  "id": "d7216cb1-aedb-471e-96f7-7fef51dedb76",
+  "version": "v1.0",
+  "template_id": "91be609a-4acd-468f-b37a-0f379893b65c",
+  "template_version": "v1.0",
+
+  "usage_purposes": [{
+    "id": "Customized shopping experience",
+    "description": "Collecting user data for offering custom tailored shopping experience",
+    "legal_basis": "<consent/legal_obligation/contract/vital_interest/public_task/legitimate_interest>",
+    "category": "Marketing"
+  }],
 
   "data_policy": {
     "policy_URL": "https://clarifyhealth.com/privacy-policy/",
     "jurisdiction": "Stockholm, Sweden",
     "industry_scope": "Healthcare",
-    "data_retention_period": "3",
-    "geographic_restriction": "Europe, Not restricted",
-    "geo_location": "Europe"
+    "data_retention_period": 31536000000, //duration in ms
+    "geographic_restriction": "Europe, Not restricted", //optional
+    "geo_location": "Europe", //optional
+    "privacy_rights_URL": "https://dataAgreeements.org/withdraw", //optional
+    "code_of_conduct": "https://example.org/CodeOfConduct" //optional
   },
 
-  "data_sharing": {
-    "exchange": true,
-    "role": "<null/issuer/verifier>"
-  },
-  
-  "personal_data":[
-    {
+  "personal_data": [{
       "attribute_id": "f216cb1-aedb-571e-46f7-2fef51dedb54",
       "attribute_name": "Name",
-      "attribute_mandatory": false, 
-      "attribute_category": "General"
+      "attribute_mandatory": false,
+      "attribute_category": "General",
+      "purposes": ["Customized shopping experience"],
+      "exchange": true,
+      "third_party_name": ["*", "did:example:456"] //List of receivers identified by their unique ids
     },
     {
       "attribute_id": "f216cb1-aedb-571e-46f7-2fef51dedb54",
       "attribute_name": "Age",
-      "attribute_mandatory": true, 
-      "attribute_category": "General"
+      "attribute_mandatory": true,
+      "attribute_category": "General",
+      "purposes": ["Customized shopping experience"],
+      "exchange": false
     }
   ],
 
-  "dpia": {
-    "dpia_done": true,
+  "dpia": { //optional
+    "dpia_conducted": true,
+    "dpia_passed": true,
     "dpia_date": "2021-05-08T08:41:59+0000",
-    "dpia_verification_url": "https://org.com/dpia_results.html"
+    "dpia_verification_url": "https://org.com/dpia_results.html" //optional
   },
 
-  "sender_metadata": {
-    "sender-did": "did:mydata:0:<sender_did_value>",
-    "preparation-time-stamp": "2021-05-08T08:41:59+0000",
-    "prepartion_signature": "<signature>"
+  "data_receiver": {
+    "id": "did:example:123",
+    "url": "",
+    "postal": "", //optional
+    "email": "", //optional
+    "phone": "" //optional
   },
-  
-  "recipient_metadata": {
-    "recipient-did": "did:mydata:1:<sender_did_value>",
-    "capture_signature": "<signature>",
-    "capture-time-stamp": "2021-05-08T08:41:59+0000"
-  }
+  "data_subject": "did:example:987",
+  "timestamp": "1629463540",
+  "service": "Example Service", //Description of the service provided with the usage of this data
+  "consent_duration": 365,
+  "form_of_consent": "explicit | implicit",
+  "termination_timestamp": "1660992340", // Optional: if present, this would mean this consent has been terminated at that point
+
+  "proofChain": [{ //Usage of linked data proofs
+    "type": "Ed25519Signature2018",
+    "created": "2020-04-02T18:28:08Z",
+    "verificationMethod": "did:example:987#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA"
+  }]
 }


### PR DESCRIPTION
Motivation behind all changes:

1- Simplification of names as discussed in call.

2- Purposes: as we consider a Data Agreement to be matched to a specific service, just like the terms of service or the privacy url, I think that the service could have multiple purposes. So it has been converted to an array, to allow the flexibility of having just one purpose (original status) or multiple purposes. I think legal_basis and category could be equivalent, so maybe that should be removed. We should check the appropriate wording, f.i: https://dpvcg.github.io/dpv/

3. Added missing fields in data_policy

4. Data sharing set at personalData level. Not all data must be shared  equally or by default if accepting a specific piece.

5. Attribute mandatory: is that necessary? If the user has already accepted it? That field seems more of a negotiation phase.

6. DPIA: distinction of done to conducted and passed. May be conducted and not passed.

7. Reference to purpose id at credential level. If you only have one purpose, then it's trivial. If you have multiple, you could have a different cardinality. Each piece of data may be required for a different reason - and subject to future modifications considering it.

8. Modification of signatures: why not use the Linked Data Proofs from the W3C - VC standards?