### PR TITLE
Adding attribute_category

### DIFF
--- a/interface-specs/data-agreement-schema/v1/data-agreement-schema.json
+++ b/interface-specs/data-agreement-schema/v1/data-agreement-schema.json
@@ -22,12 +22,14 @@
     {
       "attribute_id": "f216cb1-aedb-571e-46f7-2fef51dedb54",
       "attribute_name": "Name",
-      "attribute_sensitive": "True"
+      "attribute_sensitive": "True",
+      "attribute_category": "Name"
     },
     {
       "attribute_id": "f216cb1-aedb-571e-46f7-2fef51dedb54",
       "attribute_name": "Age",
-      "attribute_sensitive": "True"
+      "attribute_sensitive": "True",
+      "attribute_category": "Age"
     }
   ],
   "dpia": {


### PR DESCRIPTION
Adding attribute_category which is different than attribute_name. Attribute_name is a free descriptive text while attribute_category uses a convention like w3c dpv. Note PrivacyAnt has distinction in their system and in ISO has been called pii_category. See example:

        "attribute_id": "ab3464e8-0630-5f62-9854-3402aef7dfbf",
        "attribute_name": "Test Date",
        "attribute_sensitive": false,
        "attribute_category": "Date"